### PR TITLE
Minor cleanup

### DIFF
--- a/Module.cs
+++ b/Module.cs
@@ -31,17 +31,17 @@ public static class Module
       ObsBase.blogva((int)logLevel, (sbyte*)logMessagePtr, null);
   }
 
-  public static unsafe byte[] ObsText(string identifier, params object[] args)
+  public static byte[] ObsText(string identifier, params object[] args)
   {
     return Encoding.UTF8.GetBytes(string.Format(ObsTextString(identifier), args));
   }
 
-  public static unsafe byte[] ObsText(string identifier)
+  public static byte[] ObsText(string identifier)
   {
     return Encoding.UTF8.GetBytes(ObsTextString(identifier));
   }
 
-  public static unsafe string ObsTextString(string identifier, params object[] args)
+  public static string ObsTextString(string identifier, params object[] args)
   {
     return string.Format(ObsTextString(identifier), args);
   }
@@ -134,13 +134,13 @@ public static class Module
   }
 
   [UnmanagedCallersOnly(EntryPoint = "obs_module_post_load", CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
-  public static unsafe void obs_module_post_load()
+  public static void obs_module_post_load()
   {
     Log("obs_module_post_load called", ObsLogLevel.Debug);
   }
 
   [UnmanagedCallersOnly(EntryPoint = "obs_module_unload", CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
-  public static unsafe void obs_module_unload()
+  public static void obs_module_unload()
   {
     Log("obs_module_unload called", ObsLogLevel.Debug);
     SettingsDialog.Save();

--- a/Module.cs
+++ b/Module.cs
@@ -83,7 +83,7 @@ public static class Module
     switch (eventName)
     {
       case ObsInterop.obs_frontend_event.OBS_FRONTEND_EVENT_FINISHED_LOADING:
-        fixed (byte* menuItemText = Encoding.UTF8.GetBytes("C# Example Output"))
+        fixed (byte* menuItemText = "C# Example Output"u8)
           ObsFrontendApi.obs_frontend_add_tools_menu_item((sbyte*)menuItemText, &ToolsMenuItemClicked, null);
         break;
       case ObsInterop.obs_frontend_event.OBS_FRONTEND_EVENT_EXIT:

--- a/Output.cs
+++ b/Output.cs
@@ -72,9 +72,9 @@ public static class Output
   public static unsafe sbyte* output_get_name(void* data)
   {
     Module.Log("output_get_name called", ObsLogLevel.Debug);
-    var asciiBytes = Encoding.UTF8.GetBytes("C# Example Output");
-    fixed (byte* logMessagePtr = asciiBytes)
-      return (sbyte*)logMessagePtr;
+    var asciiBytes = "C# Example Output"u8;
+    fixed (byte* outputName = asciiBytes)
+      return (sbyte*)outputName;
   }
 
   [UnmanagedCallersOnly(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]

--- a/SettingsDialog.cs
+++ b/SettingsDialog.cs
@@ -83,23 +83,23 @@ public static class SettingsDialog
   {
     var properties = ObsProperties.obs_properties_create();
     fixed (byte*
-      labelId = Encoding.UTF8.GetBytes("label"),
+      labelId = "label"u8,
       labelCaption = Module.ObsText("LabelCaption"),
       labelText = Module.ObsText("LabelText"),
-      textboxId = Encoding.UTF8.GetBytes("textbox"),
+      textboxId = "textbox"u8,
       textboxCaption = Module.ObsText("TextboxCaption"),
       textboxText = Module.ObsText("TextboxText"),
-      outputStartButtonId = Encoding.UTF8.GetBytes("output_start_button"),
+      outputStartButtonId = "output_start_button"u8,
       outputStartButtonCaption = Module.ObsText("OutputStartButtonCaption"),
       outputStartButtonText = Module.ObsText("OutputStartButtonText"),
-      outputStopButtonId = Encoding.UTF8.GetBytes("output_stop_button"),
+      outputStopButtonId = "output_stop_button"u8,
       outputStopButtonCaption = Module.ObsText("OutputStopButtonCaption"),
       outputStopButtonText = Module.ObsText("OutputStopButtonText"),
-      urlButtonId = Encoding.UTF8.GetBytes("url_button"),
+      urlButtonId = "url_button"u8,
       urlButtonCaption = Module.ObsText("UrlButtonCaption"),
       urlButtonText = Module.ObsText("UrlButtonText"),
       urlButtonTarget = Module.ObsText("UrlButtonTarget"),
-      checkboxId = Encoding.UTF8.GetBytes("checkbox"),
+      checkboxId = "checkbox"u8,
       checkboxCaption = Module.ObsText("CheckboxCaption"),
       checkboxText = Module.ObsText("CheckboxText")
     )
@@ -131,7 +131,7 @@ public static class SettingsDialog
   {
     Module.Log("settings_get_defaults called", ObsLogLevel.Debug);
     fixed (byte*
-      textboxId = Encoding.UTF8.GetBytes("textbox"),
+      textboxId = "textbox"u8,
       textboxDefaultText = Module.ObsText("TextboxDefaultText")
     )
     {

--- a/Source.cs
+++ b/Source.cs
@@ -21,7 +21,7 @@ public class Source
   #region Helper methods
   public static unsafe void Register()
   {
-    new Thread(() => prepareImage("https://obsproject.com/assets/images/new_icon_small.png")).Start();
+    Task.Run(() => prepareImage("https://obsproject.com/assets/images/new_icon_small.png"));
 
     var sourceInfo = new obs_source_info();
     fixed (byte* id = Encoding.UTF8.GetBytes(Module.ModuleName + " Source"))
@@ -81,15 +81,15 @@ public class Source
   public static unsafe sbyte* image_source_get_name(void* data)
   {
     Module.Log("image_source_get_name called", ObsLogLevel.Debug);
-    fixed (byte* logMessagePtr = Encoding.UTF8.GetBytes("C# Example Image Source"))
-      return (sbyte*)logMessagePtr;
+    fixed (byte* sourceName = "C# Example Image Source"u8)
+      return (sbyte*)sourceName;
   }
 
   [UnmanagedCallersOnly(CallConvs = new[] { typeof(System.Runtime.CompilerServices.CallConvCdecl) })]
   public static unsafe void* image_source_create(obs_data* settings, obs_source* source)
   {
     Module.Log("image_source_create called", ObsLogLevel.Debug);
-    Context* context = (Context*)Marshal.AllocCoTaskMem(sizeof(Context)); ;
+    Context* context = (Context*)Marshal.AllocCoTaskMem(sizeof(Context));
     context->Settings = settings;
     context->Source = source;
     return (void*)context;
@@ -140,20 +140,20 @@ public class Source
 
     var properties = ObsProperties.obs_properties_create();
     fixed (byte*
-      labelId = Encoding.UTF8.GetBytes("label"),
+      labelId = "label"u8,
       labelCaption = Module.ObsText("LabelCaption"),
       labelText = Module.ObsText("LabelText"),
-      textboxId = Encoding.UTF8.GetBytes("textbox"),
+      textboxId = "textbox"u8,
       textboxCaption = Module.ObsText("TextboxCaption"),
       textboxText = Module.ObsText("TextboxText"),
-      buttonId = Encoding.UTF8.GetBytes("button"),
+      buttonId = "button"u8,
       buttonCaption = Module.ObsText("ButtonCaption"),
       buttonText = Module.ObsText("ButtonText"),
-      urlButtonId = Encoding.UTF8.GetBytes("url_button"),
+      urlButtonId = "url_button"u8,
       urlButtonCaption = Module.ObsText("UrlButtonCaption"),
       urlButtonText = Module.ObsText("UrlButtonText"),
       urlButtonTarget = Module.ObsText("UrlButtonTarget"),
-      checkboxId = Encoding.UTF8.GetBytes("checkbox"),
+      checkboxId = "checkbox"u8,
       checkboxCaption = Module.ObsText("CheckboxCaption"),
       checkboxText = Module.ObsText("CheckboxText")
     )
@@ -183,7 +183,7 @@ public class Source
   {
     Module.Log("image_source_get_defaults called", ObsLogLevel.Debug);
     fixed (byte*
-      textboxId = Encoding.UTF8.GetBytes("textbox"),
+      textboxId = "textbox"u8,
       textboxDefaultText = Module.ObsText("TextboxDefaultText")
     )
     {
@@ -230,7 +230,7 @@ public class Source
 
     ObsGraphics.gs_blend_state_push();
     ObsGraphics.gs_blend_function(gs_blend_type.GS_BLEND_ONE, gs_blend_type.GS_BLEND_INVSRCALPHA);
-    fixed (byte* imageParam = Encoding.UTF8.GetBytes("image"))
+    fixed (byte* imageParam = "image"u8)
       ObsGraphics.gs_effect_set_texture(ObsGraphics.gs_effect_get_param_by_name(effect, (sbyte*)imageParam), _texture);
     ObsGraphics.gs_draw_sprite(_texture, 0, _textureWidth, _textureHeight);
     ObsGraphics.gs_blend_state_pop();


### PR DESCRIPTION
- Use thread-safe collections and functions instead of locks
- Use Task.Run (reuses threads from thread pool) for tasks instead of spinning up a new thread
- Remove redundant unsafe
- Use UTF-8 string literals for compile time bytes computation instead of Encoding.UTF8.GetBytes for constant strings